### PR TITLE
Replace harmony-collections with es6-weak-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "underscore-plus": "1.x",
     "mixto": "1.x",
     "property-accessors": "^1.1",
-    "harmony-collections": "git+https://github.com/Benvie/harmony-collections.git#e81b4b808359e2def9eeeabfdee69c2989e1fe96",
     "es6-weak-map": "^0.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "underscore-plus": "1.x",
     "mixto": "1.x",
     "property-accessors": "^1.1",
-    "harmony-collections": "git+https://github.com/Benvie/harmony-collections.git#e81b4b808359e2def9eeeabfdee69c2989e1fe96"
+    "harmony-collections": "git+https://github.com/Benvie/harmony-collections.git#e81b4b808359e2def9eeeabfdee69c2989e1fe96",
+    "es6-weak-map": "^0.1.2"
   },
   "devDependencies": {
     "jasmine-focused": "1.x",

--- a/src/subscriber.coffee
+++ b/src/subscriber.coffee
@@ -1,6 +1,6 @@
 Mixin = require 'mixto'
 Signal = null
-WeakMap = global.WeakMap ? require('harmony-collections').WeakMap
+WeakMap = require 'es6-weak-map'
 Subscription = require './subscription'
 
 module.exports =


### PR DESCRIPTION
The reason is the same as in https://github.com/atom/property-accessors/pull/5.
